### PR TITLE
Fix a device orientation bug on iPhone

### DIFF
--- a/src/TouchHandler.js
+++ b/src/TouchHandler.js
@@ -37,6 +37,7 @@ export default class TouchHandler {
         el.addEventListener('touchstart', this.startFn, {passive: false});
         el.addEventListener('touchmove', this.moveFn, {passive: false});
         el.addEventListener('touchend', this.endFn, {passive: false});
+        el.addEventListener('touchcancel', this.endFn, {passive: false});
     }
 
     unbindEvents() {
@@ -44,6 +45,7 @@ export default class TouchHandler {
         el.removeEventListener('touchstart', this.startFn);
         el.removeEventListener('touchmove', this.moveFn);
         el.removeEventListener('touchend', this.endFn);
+        el.removeEventListener('touchcancel', this.endFn);
     }
 
     inRange(x, y, stick) {

--- a/src/VirtualStick.js
+++ b/src/VirtualStick.js
@@ -40,8 +40,6 @@ export class VirtualStick {
             'track-stroke-size': this.options['track-stroke-size']
         });
 
-        window.addEventListener("resize", () => this.stick.createCanvas(), false);
-
         this.options['touch-handler'].addStick(this);
     }
 


### PR DESCRIPTION
Thanks for a great library!

When we took it into use, we noticed that the stick would get stuck if it was active when changing the phone orientation between portrait and landscape.

The cause for the bug is this:

When the phone orientation changes, the touch gets cancelled and touch events for the touch `identifier` no longer get emitted. This happens without a `touchend` event, so `TouchHandler` never notices. Instead, there's a `touchcancel` event, which _does_ get emitted, but which the `TouchHandler` does not listen to.

Fix the bug by adding a listener for the `touchcancel` event, which iOS Safari emits when a touch is active when changing phone orientation.

To make the fix work, I also removed a resize event listener on `window` which seemed unnecessary. The resize listener caused a new canvas to be created just before the `touchcancel` event handler, which in turn caused an exception in [Stick#hide](https://github.com/l-brett/virtual-stick/blob/master/src/Stick.js#L112) (called indirectly by the `touchcancel` handler).